### PR TITLE
keep the ipa-build folder and the file in it

### DIFF
--- a/ipa-build
+++ b/ipa-build
@@ -203,10 +203,11 @@ $build_cmd || exit
 cd $build_path
 
 #创建ipa-build文件夹
-if [ -d ./ipa-build ];then
-	rm -rf ipa-build
+if [ ! -d ./ipa-build ];then
+#	rm -rf ipa-build
+	mkdir ipa-build
 fi
-mkdir ipa-build
+#mkdir ipa-build
 
 
 


### PR DESCRIPTION
this will keep the ipa-build folder and the file in it.
It will make the batch build/pack more easily.
User can find all the ipa file inthe ipa-build folder
